### PR TITLE
Add mdl.theme meta file

### DIFF
--- a/mdl.theme
+++ b/mdl.theme
@@ -1,0 +1,7 @@
+[Theme]
+engine = mako
+parent = base
+author = Ivan Teoh, Chris Warrick
+author_url = https://ivanteoh.com
+based_on = Material Design Lite <http://www.getmdl.io/>
+license = Apache v2


### PR DESCRIPTION
Hi there,
this PR adds a `mdl.theme` meta file, for the use of Nikola and the new themes.getnikola.com site.

On a side note, could we please take the theme (along with `carpet`) and put it in the `getnikola/nikola-themes` repo, instead of using a submodule? It would make maintenance easier for us.